### PR TITLE
[:bug: BUGFIX] Fix first displayed view

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -292,7 +292,7 @@ function displayVoteForm(recordedClick) {
 
     'use strict';
 
-    if (recordedClick.yourVote !== ZERO) {
+    if (recordedClick.yourVote && recordedClick.yourVote !== ZERO) {
         setPage('thankyou');
     } else {
         setPage('vote');


### PR DESCRIPTION
## Description
After opening the popup, the first displayed view was "thank you"
instead of "vote" or "rebuttals". Fixed by testing if certain object
property was even set.

Fixes #64
Related to ---

## Quality

- [x] Linters show no errors.
- [x] All tests passed.
- [ ] Updated README (if needed).
- [ ] Added documentation (if needed).
- [ ] Increased version.
